### PR TITLE
[StaticGeneration] Add ability to generate a static library

### DIFF
--- a/src/generateCSS.test.ts
+++ b/src/generateCSS.test.ts
@@ -520,4 +520,35 @@ describe('generateCSS', () => {
       });
     });
   });
+
+  describe('When in static mode', () => {
+    describe('Handles generating values from a PropertyConfig', () => {
+      const textAlign: PropertyConfig = {
+        cssProperty: 'text-align',
+        classNamespace: 'text',
+        valueSeparator: '-',
+        values: {
+          center: 'center',
+          left: 'left',
+          right: 'right',
+        },
+        static: {
+          values: ['center', 'left', 'right'],
+        },
+      };
+      const config: BatteryConfig = {
+        props: [textAlign],
+      };
+      it('renders valid CSS', () => {
+        testOutput(
+          generateCSS([], config, true),
+          `
+          .text-center { text-align: center }
+          .text-left { text-align: left }
+          .text-right { text-align: right }
+          `,
+        );
+      });
+    });
+  });
 });

--- a/src/generateCSS.test.ts
+++ b/src/generateCSS.test.ts
@@ -550,5 +550,43 @@ describe('generateCSS', () => {
         );
       });
     });
+
+    describe('Handles automatically generating all values from a PropertyConfig', () => {
+      const display: PropertyConfig = {
+        cssProperty: 'display',
+        classNamespace: '',
+        values: {
+          inline: 'inline',
+          block: 'block',
+          'display-none': 'none',
+          flex: 'flex',
+          'inline-flex': 'inline-flex',
+          table: 'table',
+          grid: 'grid',
+        },
+      };
+
+      const config: BatteryConfig = {
+        props: [display],
+        static: {
+          generateAllValues: true,
+        },
+      };
+
+      it('renders valid CSS', () => {
+        testOutput(
+          generateCSS([], config, true),
+          `
+            .block { display: block }
+            .display-none { display: none }
+            .flex { display: flex }
+            .grid { display: grid }
+            .inline { display: inline }
+            .inline-flex { display: inline-flex }
+            .table { display: table }
+          `,
+        );
+      });
+    });
   });
 });

--- a/src/generateCSS.ts
+++ b/src/generateCSS.ts
@@ -6,6 +6,10 @@ import { PluginConfig } from './types/plugin-config';
 import { convertSubProps } from './config/processSubProps';
 import { sortAlphaNum } from './utils/string';
 import { generateStaticValueClassNames } from './static/generateStaticValueClassNames';
+import {
+  PropertyConfig,
+  DeveloperPropertyConfig,
+} from './types/property-config';
 
 const processAtRulePlugins = (
   classMetaArr: ClassMetaData[],
@@ -100,14 +104,18 @@ const processRootCSS = (rootClasses: ClassMetaData[]) => {
   }
 };
 
+const wrapCSSPropertyInArray = (
+  propertyConfig: PropertyConfig,
+): DeveloperPropertyConfig => {
+  return { ...propertyConfig, cssProperty: [propertyConfig.cssProperty] };
+};
+
 const processConfig = (config: BatteryConfig) => {
-  const withStringCSSProperties = {
+  const withProcessedPropertyConfigs = {
     ...config,
-    props: config.props.map(prop => {
-      return { ...prop, cssProperty: [prop.cssProperty] };
-    }),
+    props: config.props.map(wrapCSSPropertyInArray),
   };
-  const withSubProps = convertSubProps(withStringCSSProperties);
+  const withSubProps = convertSubProps(withProcessedPropertyConfigs);
   return withSubProps;
 };
 

--- a/src/generateCSS.ts
+++ b/src/generateCSS.ts
@@ -5,6 +5,7 @@ import { ClassMetaData } from './types/classname';
 import { PluginConfig } from './types/plugin-config';
 import { convertSubProps } from './config/processSubProps';
 import { sortAlphaNum } from './utils/string';
+import { generateStaticValueClassNames } from './static/generateStaticValueClassNames';
 
 const processAtRulePlugins = (
   classMetaArr: ClassMetaData[],
@@ -113,9 +114,18 @@ const processConfig = (config: BatteryConfig) => {
 export const generateCSS = (
   classNames: string[],
   config: BatteryConfig,
+  generateStaticLibrary: boolean = false,
 ): string => {
+  let processedClassNames: string[];
+
+  if (generateStaticLibrary) {
+    processedClassNames = config.props.flatMap(generateStaticValueClassNames);
+  } else {
+    processedClassNames = classNames;
+  }
+
   const processedConfig = processConfig(config);
-  const classMetaArr = addMetaData(classNames, processedConfig);
+  const classMetaArr = addMetaData(processedClassNames, processedConfig);
 
   const withCssData = classMetaArr.map(classMeta => {
     classMeta.css = classMetaToCSS(classMeta, processedConfig.plugins);

--- a/src/static/generateStaticValueClassNames.ts
+++ b/src/static/generateStaticValueClassNames.ts
@@ -1,0 +1,14 @@
+import { PropertyConfig } from '../types/property-config';
+
+export const generateStaticValueClassNames = (
+  propertyConfig: PropertyConfig,
+) => {
+  if (!propertyConfig.static) {
+    return [];
+  }
+
+  const { valueSeparator = '', classNamespace } = propertyConfig;
+  const values = propertyConfig.static.values;
+
+  return values.map(value => `${classNamespace}${valueSeparator}${value}`);
+};

--- a/src/static/generateStaticValueClassNames.ts
+++ b/src/static/generateStaticValueClassNames.ts
@@ -1,7 +1,7 @@
-import { PropertyConfig } from '../types/property-config';
+import { DeveloperPropertyConfig } from '../types/property-config';
 
 export const generateStaticValueClassNames = (
-  propertyConfig: PropertyConfig,
+  propertyConfig: DeveloperPropertyConfig,
 ) => {
   if (!propertyConfig.static) {
     return [];

--- a/src/static/generateStaticValueClassNames.ts
+++ b/src/static/generateStaticValueClassNames.ts
@@ -6,9 +6,8 @@ export const generateStaticValueClassNames = (
   if (!propertyConfig.static) {
     return [];
   }
-
   const { valueSeparator = '', classNamespace } = propertyConfig;
-  const values = propertyConfig.static.values;
-
-  return values.map(value => `${classNamespace}${valueSeparator}${value}`);
+  return propertyConfig.static.values.map(
+    value => `${classNamespace}${valueSeparator}${value}`,
+  );
 };

--- a/src/types/battery-config.ts
+++ b/src/types/battery-config.ts
@@ -4,6 +4,9 @@ import { PluginConfig } from './plugin-config';
 export interface BatteryConfig {
   props: PropertyConfig[];
   plugins?: PluginConfig[];
+  static?: {
+    generateAllValues: boolean;
+  };
 }
 
 export interface DeveloperBatteryConfig {

--- a/src/types/property-config.ts
+++ b/src/types/property-config.ts
@@ -24,6 +24,7 @@ interface CorePropertyConfig {
   valueSeparator?: string;
   values?: { [k: string]: string };
   valuePlugin?: string | ModifierSubset[];
+  static?: { values: string[] };
 }
 
 export interface PropertyConfig extends CorePropertyConfig {


### PR DESCRIPTION
# Why

This PR introduces the concept of a Static library to Battery. While a fully dynamic library is very useful based only on the classes you use, it can often be really hard to determine all of the classes you use if your codebase spans multiple languages. A way to still use Battery for some of it's other useful features like auto-documentation is by generating a static library.

# How

Two relatively simple interfaces have been added to the `BatteryConfig` and `PropertyConfig` respectively. You can now add a `static` object to your `PropertyConfig` to define which of the values you would like to generate for your static library. To make things a little quicker in the case where a user only ever defines values they want included in their static library in the values object, you can have Battery do the heavy lifting and generate those lists of static values on the PropertyConfig automatically.
