### PR TITLE
feat(plugin): BatteryPlugin abstraction, and TS changes [WIP]

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests",
+      "request": "launch",
+      "args": [
+        "--runInBand"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "license": "MIT",
   "description": "Battery is a system to generate infinite, composable, atomic styles that eliminates code bloat and automatically documents itself.",
   "dependencies": {
-    "csstype": "^2.6.9"
+    "@types/lodash.merge": "^4.6.6",
+    "csstype": "^2.6.9",
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",

--- a/src/battery-plugin/index.ts
+++ b/src/battery-plugin/index.ts
@@ -14,7 +14,9 @@ import { PluginConfig } from './../types/plugin-config';
  * ```
  */
 export const BatteryPlugin = (baseConfig: PluginConfig) => {
-  return (options?: Pick<PluginConfig, 'static'>): PluginConfig => {
+  return (
+    options?: Pick<PluginConfig, 'static' | 'separator'>,
+  ): PluginConfig => {
     return merge(baseConfig, options);
   };
 };

--- a/src/battery-plugin/index.ts
+++ b/src/battery-plugin/index.ts
@@ -7,15 +7,14 @@ import { PluginConfig } from './../types/plugin-config';
  * overriding a Battery plugin configuration object, is to wrap it in
  * this function, and pass it the options you want.
  *
- *
- * Example:
- *
+ * ```ts
  * const colorPlugin = BatteryPlugin({ ... });
  *
  * colorPlugin({ static: { teal: '#008080' } })
+ * ```
  */
 export const BatteryPlugin = (baseConfig: PluginConfig) => {
-  return (options?: Pick<PluginConfig, 'static'>) => {
+  return (options?: Pick<PluginConfig, 'static'>): PluginConfig => {
     return merge(baseConfig, options);
   };
 };

--- a/src/battery-plugin/index.ts
+++ b/src/battery-plugin/index.ts
@@ -1,0 +1,21 @@
+import merge from 'lodash.merge';
+import { PluginConfig } from './../types/plugin-config';
+
+/**
+ * BatteryPlugin is a higher-order function, that allows extending
+ * the base config in a type-safe way. The preferred way of adding /
+ * overriding a Battery plugin configuration object, is to wrap it in
+ * this function, and pass it the options you want.
+ *
+ *
+ * Example:
+ *
+ * const colorPlugin = BatteryPlugin({ ... });
+ *
+ * colorPlugin({ static: { teal: '#008080' } })
+ */
+export const BatteryPlugin = (baseConfig: PluginConfig) => {
+  return (options?: Pick<PluginConfig, 'static'>) => {
+    return merge(baseConfig, options);
+  };
+};

--- a/src/classMetaData/addClassObjectData.ts
+++ b/src/classMetaData/addClassObjectData.ts
@@ -26,15 +26,14 @@ export const addClassObjectData = (
       return classMeta;
     }
 
-    const plugin: PluginConfig = config.plugins.find(
-      pluginConfig => pluginConfig.name === classMeta.valuePlugin,
-    );
+    const plugin = classMeta.valuePlugin;
+    const valuePluginType = plugin.type;
 
-    if (classMeta.valuePluginType === 'lookup') {
+    if (valuePluginType === 'lookup') {
       value = plugin.values[classMeta.explodedSource.valueIdentifier];
     }
 
-    if (classMeta.valuePluginType === 'pattern') {
+    if (valuePluginType === 'pattern') {
       value = classMeta.explodedSource.valueIdentifier;
     }
 

--- a/src/classMetaData/addClassPluginData.ts
+++ b/src/classMetaData/addClassPluginData.ts
@@ -21,22 +21,21 @@ const addAffixData = (
     modifier => modifier.identifier === affix,
   );
 
-  const pluginName = matchedPlugin.name;
   const pluginType = matchedPlugin.type;
   const modifierName = matchedModifier.name;
 
   let affixData: {
-    atrulePlugin?: string;
+    atrulePlugin?: PluginConfig;
     atruleModifier?: string;
-    selectorPlugin?: string;
+    selectorPlugin?: PluginConfig;
     selectorModifier?: string;
   } = {};
 
   if (pluginType === 'at-rule') {
-    affixData.atrulePlugin = pluginName;
+    affixData.atrulePlugin = matchedPlugin;
     affixData.atruleModifier = modifierName;
   } else if (pluginType === 'selector') {
-    affixData.selectorPlugin = pluginName;
+    affixData.selectorPlugin = matchedPlugin;
     affixData.selectorModifier = modifierName;
   }
 

--- a/src/classMetaData/addExplodedSourceData.ts
+++ b/src/classMetaData/addExplodedSourceData.ts
@@ -23,7 +23,9 @@ const setValueSeparator = (
   propConfig: DeveloperPropertyConfig,
   classMeta: ClassMetaData,
 ): ExplodedClassSource => {
-  const { valueSeparator = '', pluginSeparator = '' } = propConfig;
+  const { valueSeparator = '', valuePlugin } = propConfig;
+  const pluginSeparator = (valuePlugin && valuePlugin.separator) || '';
+
   const valueOrPluginSeparator = classMeta.keyword
     ? valueSeparator
     : pluginSeparator;

--- a/src/classMetaData/addExplodedSourceData.ts
+++ b/src/classMetaData/addExplodedSourceData.ts
@@ -35,7 +35,6 @@ const setModifierData = (
   explodedSource: ExplodedClassSource,
   classMeta: ClassMetaData,
   matchers: Matchers,
-  plugins: PluginConfig[],
 ): ExplodedClassSource => {
   const value = classMeta.source.match(
     matchers[classMeta.property.join('')],
@@ -147,7 +146,6 @@ const setPrefixSuffixData = (
   matchers: Matchers,
   plugins: PluginConfig[],
 ) => {
-  //todo: fix types
   const matcherArr = Object.entries(matchers).find(([matcherName]) => {
     return (
       matcherName === classMeta.property.join('') ||
@@ -227,7 +225,6 @@ export const addExplodedSourceData = (
         withValueSeparator,
         classMeta,
         matchers,
-        plugins,
       );
     }
 

--- a/src/classMetaData/addExplodedSourceData.ts
+++ b/src/classMetaData/addExplodedSourceData.ts
@@ -37,10 +37,11 @@ const setModifierData = (
   matchers: Matchers,
   plugins: PluginConfig[],
 ): ExplodedClassSource => {
-  const value = classMeta.source.match(matchers[classMeta.valuePlugin])[3];
-  const plugin = plugins.find(
-    pluginConfig => pluginConfig.name === classMeta.valuePlugin,
-  );
+  const value = classMeta.source.match(
+    matchers[classMeta.property.join('')],
+  )[3];
+
+  const plugin = classMeta.valuePlugin;
 
   if (plugin.modifiers) {
     const valuePluginMatcher = generateValueMatcher(plugin, true);
@@ -88,7 +89,10 @@ const determinePluginValueIdentifier = (
   classMeta: ClassMetaData,
   matchers: Matchers,
 ) => {
-  const value = classMeta.source.match(matchers[classMeta.valuePlugin])[3];
+  const value = classMeta.source.match(
+    matchers[classMeta.property.join('')],
+  )[3];
+
   const { modifierIdentifier, modifierSeparator } = explodedSource;
 
   return value.replace(modifierIdentifier, '').replace(modifierSeparator, '');
@@ -143,9 +147,10 @@ const setPrefixSuffixData = (
   matchers: Matchers,
   plugins: PluginConfig[],
 ) => {
+  //todo: fix types
   const matcherArr = Object.entries(matchers).find(([matcherName]) => {
     return (
-      matcherName === classMeta.valuePlugin ||
+      matcherName === classMeta.property.join('') ||
       (classMeta.keyword && matcherName === 'keyword')
     );
   });

--- a/src/classMetaData/addMetaData.test.ts
+++ b/src/classMetaData/addMetaData.test.ts
@@ -275,7 +275,7 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['background-color'],
           valuePlugin: colorPlugin(),
-          atrulePlugin: 'breakpoint',
+          atrulePlugin: breakpointPlugin(),
           atruleModifier: 'responsiveMedium',
           explodedSource: {
             prefix: '',
@@ -298,7 +298,7 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['background-color'],
           valuePlugin: colorPlugin(),
-          selectorPlugin: 'pseudo',
+          selectorPlugin: pseudoPlugin(),
           selectorModifier: 'hover',
           explodedSource: {
             prefix: 'hover',
@@ -322,7 +322,7 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['z-index'],
           valuePlugin: integerPlugin(),
-          atrulePlugin: 'breakpoint',
+          atrulePlugin: breakpointPlugin(),
           atruleModifier: 'responsiveLarge',
           explodedSource: {
             prefix: '',
@@ -344,7 +344,7 @@ describe('addMetaData', () => {
           selector: 'hover-item-bg-contain',
           keyword: true,
           property: ['background-size'],
-          selectorPlugin: 'hoverTarget',
+          selectorPlugin: hoverTargetPlugin(),
           selectorModifier: 'hoverItem',
           explodedSource: {
             prefix: 'hover-item',

--- a/src/classMetaData/addMetaData.test.ts
+++ b/src/classMetaData/addMetaData.test.ts
@@ -144,7 +144,6 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['background-color'],
           valuePlugin: colorPlugin(),
-          valuePluginType: 'lookup',
           explodedSource: {
             prefix: '',
             prefixSeparator: '',
@@ -166,7 +165,6 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['background-color'],
           valuePlugin: colorPlugin(),
-          valuePluginType: 'lookup',
           explodedSource: {
             prefix: '',
             prefixSeparator: '',
@@ -189,7 +187,6 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['z-index'],
           valuePlugin: integerPlugin(),
-          valuePluginType: 'pattern',
           explodedSource: {
             prefix: '',
             prefixSeparator: '',
@@ -211,7 +208,6 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['width'],
           valuePlugin: lengthUnitsPlugin(),
-          valuePluginType: 'pattern',
           explodedSource: {
             prefix: '',
             prefixSeparator: '',
@@ -279,7 +275,6 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['background-color'],
           valuePlugin: colorPlugin(),
-          valuePluginType: 'lookup',
           atrulePlugin: 'breakpoint',
           atruleModifier: 'responsiveMedium',
           explodedSource: {
@@ -303,7 +298,6 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['background-color'],
           valuePlugin: colorPlugin(),
-          valuePluginType: 'lookup',
           selectorPlugin: 'pseudo',
           selectorModifier: 'hover',
           explodedSource: {
@@ -328,7 +322,6 @@ describe('addMetaData', () => {
           keyword: false,
           property: ['z-index'],
           valuePlugin: integerPlugin(),
-          valuePluginType: 'pattern',
           atrulePlugin: 'breakpoint',
           atruleModifier: 'responsiveLarge',
           explodedSource: {

--- a/src/classMetaData/addMetaData.test.ts
+++ b/src/classMetaData/addMetaData.test.ts
@@ -114,8 +114,7 @@ describe('addMetaData', () => {
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
-          pluginSeparator: '-',
-          valuePlugin: colorPlugin(),
+          valuePlugin: colorPlugin({ separator: '-' }),
         },
         {
           cssProperty: ['background-size'],
@@ -239,8 +238,7 @@ describe('addMetaData', () => {
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
-          pluginSeparator: '-',
-          valuePlugin: colorPlugin(),
+          valuePlugin: colorPlugin({ separator: '-' }),
         },
         {
           cssProperty: ['background-size'],

--- a/src/classMetaData/addMetaData.test.ts
+++ b/src/classMetaData/addMetaData.test.ts
@@ -31,7 +31,7 @@ describe('addMetaData', () => {
             contain: 'contain',
             cover: 'cover',
           },
-          valuePlugin: 'lengthUnit',
+          valuePlugin: lengthUnitsPlugin(),
         },
       ],
     };
@@ -109,13 +109,13 @@ describe('addMetaData', () => {
         {
           cssProperty: ['z-index'],
           classNamespace: 'z',
-          valuePlugin: 'integer',
+          valuePlugin: integerPlugin(),
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin(),
         },
         {
           cssProperty: ['background-size'],
@@ -125,15 +125,14 @@ describe('addMetaData', () => {
             contain: 'contain',
             cover: 'cover',
           },
-          valuePlugin: 'lengthUnit',
+          valuePlugin: lengthUnitsPlugin(),
         },
         {
           cssProperty: ['width'],
           classNamespace: 'w',
-          valuePlugin: 'lengthUnit',
+          valuePlugin: lengthUnitsPlugin(),
         },
       ],
-      plugins: [integerPlugin, colorPlugin, lengthUnitsPlugin],
     };
     const inputClassNames = ['bg-white', 'bg-white_10', 'z100', 'w3'];
 
@@ -144,7 +143,7 @@ describe('addMetaData', () => {
           selector: 'bg-white',
           keyword: false,
           property: ['background-color'],
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin(),
           valuePluginType: 'lookup',
           explodedSource: {
             prefix: '',
@@ -166,7 +165,7 @@ describe('addMetaData', () => {
           selector: 'bg-white_10',
           keyword: false,
           property: ['background-color'],
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin(),
           valuePluginType: 'lookup',
           explodedSource: {
             prefix: '',
@@ -189,7 +188,7 @@ describe('addMetaData', () => {
           selector: 'z100',
           keyword: false,
           property: ['z-index'],
-          valuePlugin: 'integer',
+          valuePlugin: integerPlugin(),
           valuePluginType: 'pattern',
           explodedSource: {
             prefix: '',
@@ -211,7 +210,7 @@ describe('addMetaData', () => {
           selector: 'w3',
           keyword: false,
           property: ['width'],
-          valuePlugin: 'lengthUnit',
+          valuePlugin: lengthUnitsPlugin(),
           valuePluginType: 'pattern',
           explodedSource: {
             prefix: '',
@@ -239,13 +238,13 @@ describe('addMetaData', () => {
         {
           cssProperty: ['z-index'],
           classNamespace: 'z',
-          valuePlugin: 'integer',
+          valuePlugin: integerPlugin(),
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin(),
         },
         {
           cssProperty: ['background-size'],
@@ -255,22 +254,15 @@ describe('addMetaData', () => {
             contain: 'contain',
             cover: 'cover',
           },
-          valuePlugin: 'lengthUnit',
+          valuePlugin: lengthUnitsPlugin(),
         },
         {
           cssProperty: ['width'],
           classNamespace: 'w',
-          valuePlugin: 'lengthUnit',
+          valuePlugin: lengthUnitsPlugin(),
         },
       ],
-      plugins: [
-        integerPlugin,
-        colorPlugin,
-        lengthUnitsPlugin,
-        breakpointPlugin,
-        pseudoPlugin,
-        hoverTargetPlugin,
-      ],
+      plugins: [breakpointPlugin(), pseudoPlugin(), hoverTargetPlugin()],
     };
     const inputClassNames = [
       'bg-white-md',
@@ -286,7 +278,7 @@ describe('addMetaData', () => {
           selector: 'bg-white-md',
           keyword: false,
           property: ['background-color'],
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin(),
           valuePluginType: 'lookup',
           atrulePlugin: 'breakpoint',
           atruleModifier: 'responsiveMedium',
@@ -310,7 +302,7 @@ describe('addMetaData', () => {
           selector: 'hover-bg-white_10',
           keyword: false,
           property: ['background-color'],
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin(),
           valuePluginType: 'lookup',
           selectorPlugin: 'pseudo',
           selectorModifier: 'hover',
@@ -335,7 +327,7 @@ describe('addMetaData', () => {
           selector: 'z100-lg',
           keyword: false,
           property: ['z-index'],
-          valuePlugin: 'integer',
+          valuePlugin: integerPlugin(),
           valuePluginType: 'pattern',
           atrulePlugin: 'breakpoint',
           atruleModifier: 'responsiveLarge',

--- a/src/classMetaData/addMetaData.ts
+++ b/src/classMetaData/addMetaData.ts
@@ -7,35 +7,9 @@ import { generateMatchers } from '../matchers/generateMatchers';
 import { keywordToMetaData } from './keywordToMetaData';
 import { addPropertyData } from './addPropertyData';
 import { addValuePluginData } from './addValuePluginData';
-import { Matchers } from '../types/matchers';
-import { PluginConfig } from '../types/plugin-config';
 import { addExplodedSourceData } from './addExplodedSourceData';
 import { addModifierPluginData } from './addModifierPluginData';
 import { addClassPluginData } from './addClassPluginData';
-
-const getPlugins = (
-  pluginTypes: string[],
-  matchers: Matchers,
-  plugins: PluginConfig[],
-) => {
-  if (!plugins) return {};
-
-  return Object.entries(matchers)
-    .filter(([matcherName]) => {
-      const valuePlugins = plugins
-        .filter(plugin => pluginTypes.includes(plugin.type))
-        .map(plugin => `${plugin.name}`);
-
-      return valuePlugins.includes(matcherName);
-    })
-    .reduce(
-      (accum, [matcherName, regex]) => {
-        accum[matcherName] = regex;
-        return accum;
-      },
-      {} as Matchers,
-    );
-};
 
 const sortValidAndInvalid = (classMeta: ClassMetaData[]) =>
   classMeta.reduce(
@@ -62,11 +36,8 @@ export const addMetaData = (
 ): ClassMetaData[] => {
   const keywords = keywordToMetaData(config);
   const matchers = generateMatchers(config, keywords);
-  const valuePluginMatchers = getPlugins(
-    ['pattern', 'lookup'],
-    matchers,
-    config.plugins,
-  );
+
+  console.log({ matchers });
 
   // Adds: source, invalid, selector
   const withSourceData = addSourceData(classNames, matchers);
@@ -75,11 +46,11 @@ export const addMetaData = (
   // Adds: keyword
   const withKeywordData = addKeywordData(validClassMeta, matchers);
 
-  // Adds: valuePlugin, valuePluginType
+  // Adds: valuePlugin
   const withValuePluginData = addValuePluginData(
     withKeywordData,
-    valuePluginMatchers,
-    config.plugins,
+    matchers,
+    config.props,
   );
 
   // Adds: property

--- a/src/classMetaData/addMetaData.ts
+++ b/src/classMetaData/addMetaData.ts
@@ -8,7 +8,7 @@ import { keywordToMetaData } from './keywordToMetaData';
 import { addPropertyData } from './addPropertyData';
 import { addValuePluginData } from './addValuePluginData';
 import { addExplodedSourceData } from './addExplodedSourceData';
-import { addModifierPluginData } from './addModifierPluginData';
+import { addValueModifierPluginData } from './addValueModifierPluginData';
 import { addClassPluginData } from './addClassPluginData';
 
 const sortValidAndInvalid = (classMeta: ClassMetaData[]) =>
@@ -70,10 +70,7 @@ export const addMetaData = (
   );
 
   // Adds: valueModifier
-  const withModifierPlugin = addModifierPluginData(
-    withExplodedSourceData,
-    config.plugins,
-  );
+  const withModifierPlugin = addValueModifierPluginData(withExplodedSourceData);
 
   // Adds: selectorPlugin, atrulePlugin
   const withClassPluginData = addClassPluginData(

--- a/src/classMetaData/addMetaData.ts
+++ b/src/classMetaData/addMetaData.ts
@@ -37,7 +37,7 @@ export const addMetaData = (
   const keywords = keywordToMetaData(config);
   const matchers = generateMatchers(config, keywords);
 
-  console.log({ matchers });
+  console.log('DEBUG:', { matchers });
 
   // Adds: source, invalid, selector
   const withSourceData = addSourceData(classNames, matchers);

--- a/src/classMetaData/addMetaData.ts
+++ b/src/classMetaData/addMetaData.ts
@@ -37,8 +37,6 @@ export const addMetaData = (
   const keywords = keywordToMetaData(config);
   const matchers = generateMatchers(config, keywords);
 
-  console.log('DEBUG:', { matchers });
-
   // Adds: source, invalid, selector
   const withSourceData = addSourceData(classNames, matchers);
   const { validClassMeta } = sortValidAndInvalid(withSourceData);

--- a/src/classMetaData/addModifierPluginData.ts
+++ b/src/classMetaData/addModifierPluginData.ts
@@ -12,9 +12,7 @@ export const addModifierPluginData = (
 
     const { modifierIdentifier } = classMeta.explodedSource;
     const hasNonDefaultModifier = modifierIdentifier.length > 0;
-    const plugin = plugins.find(plugin => {
-      return plugin.name === classMeta.valuePlugin;
-    });
+    const plugin = classMeta.valuePlugin;
 
     if (!plugin || !plugin.modifiers) return classMeta;
 

--- a/src/classMetaData/addPropertyData.ts
+++ b/src/classMetaData/addPropertyData.ts
@@ -40,7 +40,7 @@ export const addPropertyData = (
     const property = props.find(prop => {
       const valuePluginKey = prop.cssProperty.join('');
 
-      console.log({ valuePluginKey, matcherName });
+      console.log('DEBUG:', { valuePluginKey, matcherName });
 
       if (classNamespace.length > 0 && prop.classNamespace) {
         const matched = prop.classNamespace.match(new RegExp(classNamespace));

--- a/src/classMetaData/addPropertyData.ts
+++ b/src/classMetaData/addPropertyData.ts
@@ -38,13 +38,15 @@ export const addPropertyData = (
       .replace(pluginSeparatorsRegex, '');
 
     const property = props.find(prop => {
+      const valuePluginKey = prop.cssProperty.join('');
+
+      console.log({ valuePluginKey, matcherName });
+
       if (classNamespace.length > 0 && prop.classNamespace) {
         const matched = prop.classNamespace.match(new RegExp(classNamespace));
-        return (
-          prop.valuePlugin === matcherName && matched && matched.length > 0
-        );
+        return valuePluginKey === matcherName && matched && matched.length > 0;
       } else if (classNamespace.length === 0 && prop.pluginDefault) {
-        return prop.valuePlugin === matcherName && prop.pluginDefault;
+        return valuePluginKey === matcherName && prop.pluginDefault;
       } else {
         return false;
       }

--- a/src/classMetaData/addPropertyData.ts
+++ b/src/classMetaData/addPropertyData.ts
@@ -40,8 +40,6 @@ export const addPropertyData = (
     const property = props.find(prop => {
       const valuePluginKey = prop.cssProperty.join('');
 
-      console.log('DEBUG:', { valuePluginKey, matcherName });
-
       if (classNamespace.length > 0 && prop.classNamespace) {
         const matched = prop.classNamespace.match(new RegExp(classNamespace));
         return valuePluginKey === matcherName && matched && matched.length > 0;

--- a/src/classMetaData/addPropertyData.ts
+++ b/src/classMetaData/addPropertyData.ts
@@ -30,7 +30,9 @@ export const addPropertyData = (
     }
 
     const pluginSeparatorsRegex = new RegExp(
-      `[${props.map(prop => prop.pluginSeparator).join('')}]`,
+      `[${props
+        .map(prop => (prop.valuePlugin || {}).separator || '')
+        .join('')}]`,
     );
 
     const classNamespace = classMeta.source

--- a/src/classMetaData/addValueModifierPluginData.ts
+++ b/src/classMetaData/addValueModifierPluginData.ts
@@ -1,15 +1,9 @@
 import { ClassMetaData } from '../types/classname';
-import { PluginConfig } from '../types/plugin-config';
 import { getMatcherName } from '../matchers/utils';
 import { generateModifierMatchers } from '../matchers/generateModifierMatchers';
 
-export const addModifierPluginData = (
-  classMetaArr: ClassMetaData[],
-  plugins: PluginConfig[],
-) => {
+export const addValueModifierPluginData = (classMetaArr: ClassMetaData[]) => {
   return classMetaArr.map(classMeta => {
-    if (!plugins || plugins.length < 1) return classMeta;
-
     const { modifierIdentifier } = classMeta.explodedSource;
     const hasNonDefaultModifier = modifierIdentifier.length > 0;
     const plugin = classMeta.valuePlugin;

--- a/src/classMetaData/addValuePluginData.ts
+++ b/src/classMetaData/addValuePluginData.ts
@@ -1,27 +1,24 @@
+import { DeveloperPropertyConfig } from './../types/property-config';
 import { ClassMetaData } from '../types/classname';
 import { Matchers } from '../types/matchers';
-import { PluginConfig } from '../types/plugin-config';
 
 export const addValuePluginData = (
   classMetaArr: ClassMetaData[],
   valuePluginMatchers: Matchers,
-  plugins: PluginConfig[],
+  propConfigs: DeveloperPropertyConfig[],
 ): ClassMetaData[] => {
   return classMetaArr.map(classMeta => {
     if (classMeta.keyword) return classMeta;
-    const pluginName = Object.entries(valuePluginMatchers).find(([, regex]) => {
-      return regex.test(classMeta.source);
-    });
 
-    const plugin: PluginConfig = plugins.find(
-      pluginConfig => pluginConfig.name === pluginName[0],
+    const [matcherName, regex] = Object.entries(valuePluginMatchers).find(
+      ([, regex]) => regex.test(classMeta.source),
     );
 
-    classMeta.valuePlugin = plugin.name;
+    const propConfig = propConfigs.find(
+      config => config.cssProperty.join('') === matcherName,
+    );
 
-    if (plugin.type === 'lookup' || plugin.type === 'pattern') {
-      classMeta.valuePluginType = plugin.type;
-    }
+    classMeta.valuePlugin = propConfig.valuePlugin;
 
     return classMeta;
   });

--- a/src/classMetaData/keywordToMetaData.test.ts
+++ b/src/classMetaData/keywordToMetaData.test.ts
@@ -1,6 +1,7 @@
 import { keywordToMetaData } from './keywordToMetaData';
 import { DeveloperBatteryConfig } from '../types/battery-config';
 import { ClassMetaData } from '../types/classname';
+import { lengthUnitsPlugin } from '../fixtures/plugins/lengthUnits';
 
 describe('keywordToMetaData', () => {
   describe('Given a config containing keyword class definitions', () => {
@@ -15,7 +16,7 @@ describe('keywordToMetaData', () => {
               contain: 'contain',
               cover: 'cover',
             },
-            valuePlugin: 'lengthUnits',
+            valuePlugin: lengthUnitsPlugin(),
           },
         ],
       };

--- a/src/config/processSubProps.test.ts
+++ b/src/config/processSubProps.test.ts
@@ -1,6 +1,7 @@
 import { convertSubProps } from './processSubProps';
 import { DeveloperPropertyConfig } from '../types/property-config';
 import { DeveloperBatteryConfig } from '../types/battery-config';
+import { lengthUnitsPlugin } from '../fixtures/plugins/lengthUnits';
 
 describe('processSubProps', () => {
   it('converts configs with subProps into their own separate configs', () => {
@@ -20,7 +21,7 @@ describe('processSubProps', () => {
       values: {
         auto: 'auto',
       },
-      valuePlugin: 'lengthUnit',
+      valuePlugin: lengthUnitsPlugin(),
     };
 
     const props = [margin];
@@ -32,7 +33,7 @@ describe('processSubProps', () => {
         values: {
           auto: 'auto',
         },
-        valuePlugin: 'lengthUnit',
+        valuePlugin: lengthUnitsPlugin(),
       },
       {
         cssProperty: ['margin-top'],
@@ -41,7 +42,7 @@ describe('processSubProps', () => {
         values: {
           auto: 'auto',
         },
-        valuePlugin: 'lengthUnit',
+        valuePlugin: lengthUnitsPlugin(),
       },
       {
         cssProperty: ['margin-right'],
@@ -50,7 +51,7 @@ describe('processSubProps', () => {
         values: {
           auto: 'auto',
         },
-        valuePlugin: 'lengthUnit',
+        valuePlugin: lengthUnitsPlugin(),
       },
       {
         cssProperty: ['margin-bottom'],
@@ -59,7 +60,7 @@ describe('processSubProps', () => {
         values: {
           auto: 'auto',
         },
-        valuePlugin: 'lengthUnit',
+        valuePlugin: lengthUnitsPlugin(),
       },
       {
         cssProperty: ['margin-left'],
@@ -68,7 +69,7 @@ describe('processSubProps', () => {
         values: {
           auto: 'auto',
         },
-        valuePlugin: 'lengthUnit',
+        valuePlugin: lengthUnitsPlugin(),
       },
       {
         cssProperty: ['margin-top', 'margin-bottom'],
@@ -77,7 +78,7 @@ describe('processSubProps', () => {
         values: {
           auto: 'auto',
         },
-        valuePlugin: 'lengthUnit',
+        valuePlugin: lengthUnitsPlugin(),
       },
       {
         cssProperty: ['margin-right', 'margin-left'],
@@ -86,7 +87,7 @@ describe('processSubProps', () => {
         values: {
           auto: 'auto',
         },
-        valuePlugin: 'lengthUnit',
+        valuePlugin: lengthUnitsPlugin(),
       },
     ];
 

--- a/src/css/classMetaToCSS.ts
+++ b/src/css/classMetaToCSS.ts
@@ -12,9 +12,9 @@ export const classMetaToCSS = (
     .join(';');
 
   if (classMeta.selectorPlugin) {
-    const selectorModifier = plugins
-      .find(plugin => plugin.name === classMeta.selectorPlugin)
-      .modifiers.find(modifier => modifier.name === classMeta.selectorModifier);
+    const selectorModifier = classMeta.selectorPlugin.modifiers.find(
+      modifier => modifier.name === classMeta.selectorModifier,
+    );
 
     classMeta.selector = selectorModifier.modifierFn(
       classMeta.selector,

--- a/src/fixtures/plugins/breakpoint.ts
+++ b/src/fixtures/plugins/breakpoint.ts
@@ -1,6 +1,6 @@
-import { PluginConfig } from '../../types/plugin-config';
+import { BatteryPlugin } from './../../battery-plugin';
 
-export const breakpointPlugin: PluginConfig = {
+export const breakpointPlugin = BatteryPlugin({
   type: 'at-rule',
   atrule: 'media',
   affixType: 'suffix',
@@ -24,4 +24,4 @@ export const breakpointPlugin: PluginConfig = {
       condition: '(min-width: 1040px)',
     },
   ],
-};
+});

--- a/src/fixtures/plugins/breakpoint.ts
+++ b/src/fixtures/plugins/breakpoint.ts
@@ -1,7 +1,6 @@
 import { PluginConfig } from '../../types/plugin-config';
 
 export const breakpointPlugin: PluginConfig = {
-  name: 'breakpoint',
   type: 'at-rule',
   atrule: 'media',
   affixType: 'suffix',

--- a/src/fixtures/plugins/color.ts
+++ b/src/fixtures/plugins/color.ts
@@ -1,4 +1,5 @@
-import { PluginConfig, ModifierFn } from '../../types/plugin-config';
+import { BatteryPlugin } from './../../battery-plugin';
+import { ModifierFn } from '../../types/plugin-config';
 
 const hexToRgba: ModifierFn = (hex, opacity) => {
   const hexValue = hex.replace('#', '');
@@ -9,7 +10,7 @@ const hexToRgba: ModifierFn = (hex, opacity) => {
   return `rgba(${r},${g},${b},${parseInt(opacity) / 100})`;
 };
 
-export const colorPlugin: PluginConfig = {
+export const colorPlugin = BatteryPlugin({
   type: 'lookup',
   values: {
     black: '#000000',
@@ -24,4 +25,4 @@ export const colorPlugin: PluginConfig = {
       modifierFn: hexToRgba,
     },
   ],
-};
+});

--- a/src/fixtures/plugins/color.ts
+++ b/src/fixtures/plugins/color.ts
@@ -11,7 +11,6 @@ const hexToRgba: ModifierFn = (hex, opacity) => {
 
 export const colorPlugin: PluginConfig = {
   type: 'lookup',
-  name: 'color',
   values: {
     black: '#000000',
     white: '#FFFFFF',

--- a/src/fixtures/plugins/hoverTarget.ts
+++ b/src/fixtures/plugins/hoverTarget.ts
@@ -1,6 +1,6 @@
-import { PluginConfig } from '../../types/plugin-config';
+import { BatteryPlugin } from './../../battery-plugin';
 
-export const hoverTargetPlugin: PluginConfig = {
+export const hoverTargetPlugin = BatteryPlugin({
   type: 'selector',
   affixType: 'prefix',
   modifiers: [
@@ -11,4 +11,4 @@ export const hoverTargetPlugin: PluginConfig = {
       modifierFn: selector => `hover-target:hover .${selector}`,
     },
   ],
-};
+});

--- a/src/fixtures/plugins/hoverTarget.ts
+++ b/src/fixtures/plugins/hoverTarget.ts
@@ -1,7 +1,6 @@
 import { PluginConfig } from '../../types/plugin-config';
 
 export const hoverTargetPlugin: PluginConfig = {
-  name: 'hoverTarget',
   type: 'selector',
   affixType: 'prefix',
   modifiers: [

--- a/src/fixtures/plugins/integer.ts
+++ b/src/fixtures/plugins/integer.ts
@@ -1,6 +1,6 @@
-import { PluginConfig } from '../../types/plugin-config';
+import { BatteryPlugin } from './../../battery-plugin';
 
-export const integerPlugin: PluginConfig = {
+export const integerPlugin = BatteryPlugin({
   type: 'pattern',
   identifier: /-?\d{1,4}/,
-};
+});

--- a/src/fixtures/plugins/integer.ts
+++ b/src/fixtures/plugins/integer.ts
@@ -2,6 +2,5 @@ import { PluginConfig } from '../../types/plugin-config';
 
 export const integerPlugin: PluginConfig = {
   type: 'pattern',
-  name: 'integer',
   identifier: /-?\d{1,4}/,
 };

--- a/src/fixtures/plugins/lengthUnits.ts
+++ b/src/fixtures/plugins/lengthUnits.ts
@@ -9,7 +9,6 @@ const ratio: ModifierFn = value => {
 
 export const lengthUnitsPlugin: PluginConfig = {
   type: 'pattern',
-  name: 'lengthUnit',
   identifier: /-?\d+/,
   modifiers: [
     {

--- a/src/fixtures/plugins/lengthUnits.ts
+++ b/src/fixtures/plugins/lengthUnits.ts
@@ -1,4 +1,5 @@
-import { ModifierFn, PluginConfig } from '../../types/plugin-config';
+import { BatteryPlugin } from './../../battery-plugin';
+import { ModifierFn } from '../../types/plugin-config';
 
 const pxToRem: ModifierFn = value => `${parseInt(value) / 16}rem`;
 const ratio: ModifierFn = value => {
@@ -7,7 +8,7 @@ const ratio: ModifierFn = value => {
   return pxToRem(convertedValue);
 };
 
-export const lengthUnitsPlugin: PluginConfig = {
+export const lengthUnitsPlugin = BatteryPlugin({
   type: 'pattern',
   identifier: /-?\d+/,
   modifiers: [
@@ -37,4 +38,4 @@ export const lengthUnitsPlugin: PluginConfig = {
       modifierFn: value => `${value}vw`,
     },
   ],
-};
+});

--- a/src/fixtures/plugins/pseudo.ts
+++ b/src/fixtures/plugins/pseudo.ts
@@ -1,6 +1,6 @@
-import { PluginConfig } from '../../types/plugin-config';
+import { BatteryPlugin } from './../../battery-plugin';
 
-export const pseudoPlugin: PluginConfig = {
+export const pseudoPlugin = BatteryPlugin({
   type: 'selector',
   affixType: 'prefix',
   modifiers: [
@@ -17,4 +17,4 @@ export const pseudoPlugin: PluginConfig = {
       modifierFn: selector => `${selector}:focus`,
     },
   ],
-};
+});

--- a/src/fixtures/plugins/pseudo.ts
+++ b/src/fixtures/plugins/pseudo.ts
@@ -1,7 +1,6 @@
 import { PluginConfig } from '../../types/plugin-config';
 
 export const pseudoPlugin: PluginConfig = {
-  name: 'pseudo',
   type: 'selector',
   affixType: 'prefix',
   modifiers: [

--- a/src/fixtures/props/background-size.ts
+++ b/src/fixtures/props/background-size.ts
@@ -1,4 +1,5 @@
 import { PropertyConfig } from '../../types/property-config';
+import { lengthUnitsPlugin } from '../../fixtures/plugins/lengthUnits';
 
 export const backgroundSize: PropertyConfig = {
   cssProperty: 'background-size',
@@ -8,5 +9,5 @@ export const backgroundSize: PropertyConfig = {
     contain: 'contain',
     cover: 'cover',
   },
-  valuePlugin: 'lengthUnit',
+  valuePlugin: lengthUnitsPlugin(),
 };

--- a/src/fixtures/props/margin.ts
+++ b/src/fixtures/props/margin.ts
@@ -1,4 +1,5 @@
 import { PropertyConfig } from '../../types/property-config';
+import { lengthUnitsPlugin } from '../../fixtures/plugins/lengthUnits';
 
 export const margin: PropertyConfig = {
   cssProperty: 'margin',
@@ -17,5 +18,5 @@ export const margin: PropertyConfig = {
     auto: 'auto',
     inherit: 'inherit',
   },
-  valuePlugin: 'lengthUnit',
+  valuePlugin: lengthUnitsPlugin(),
 };

--- a/src/fixtures/props/width.ts
+++ b/src/fixtures/props/width.ts
@@ -1,7 +1,8 @@
 import { PropertyConfig } from '../../types/property-config';
+import { lengthUnitsPlugin } from '../../fixtures/plugins/lengthUnits';
 
 export const width: PropertyConfig = {
   cssProperty: 'width',
   classNamespace: 'w',
-  valuePlugin: 'lengthUnit',
+  valuePlugin: lengthUnitsPlugin(),
 };

--- a/src/generateCSS.test.ts
+++ b/src/generateCSS.test.ts
@@ -238,7 +238,7 @@ describe('generateCSS', () => {
       };
 
       it('renders valid CSS', () => {
-        testOutput(generateCSS(input, config), '.m3 { margin: 1.8rem }');
+        testOutput(generateCSS(input, config), '.m3 { margin: 1.125rem }');
       });
     });
   });

--- a/src/generateCSS.test.ts
+++ b/src/generateCSS.test.ts
@@ -16,7 +16,7 @@ const testOutput = (source: string, expectation: string) => {
 
 describe('generateCSS', () => {
   describe('Handles keywords', () => {
-    describe('with propIndicator', () => {
+    describe('with classNamespace', () => {
       const input = ['bg-contain', 'text-center'];
       const config: BatteryConfig = {
         props: [
@@ -48,7 +48,7 @@ describe('generateCSS', () => {
       });
     });
 
-    describe('with NO propIndicator', () => {
+    describe('with NO classNamespace', () => {
       const input = ['block', 'absolute'];
       const config: BatteryConfig = {
         props: [
@@ -71,6 +71,37 @@ describe('generateCSS', () => {
         testOutput(
           generateCSS(input, config),
           '.block { display: block } .absolute { position: absolute }',
+        );
+      });
+    });
+
+    describe('with clashing classNamespaces', () => {
+      const input = ['bg-contain', 'bg100p', 'bg-black'];
+      const config: BatteryConfig = {
+        props: [
+          {
+            cssProperty: 'background-size',
+            classNamespace: 'bg',
+            valueSeparator: '-',
+            valuePlugin: lengthUnitsPlugin(),
+            values: {
+              contain: 'contain',
+              cover: 'cover',
+            },
+          },
+          {
+            cssProperty: 'background-color',
+            classNamespace: 'bg',
+            pluginSeparator: '-',
+            valuePlugin: colorPlugin(),
+          },
+        ],
+      };
+
+      test('renders valid CSS', () => {
+        testOutput(
+          generateCSS(input, config),
+          '.bg-black { background-color: #000000 } .bg-contain { background-size: contain } .bg100p { background-size: 100% }',
         );
       });
     });

--- a/src/generateCSS.test.ts
+++ b/src/generateCSS.test.ts
@@ -1,6 +1,8 @@
 import { generateCSS } from './generateCSS';
 import { BatteryConfig } from './types/battery-config';
 import { ModifierFn } from './types/plugin-config';
+import { colorPlugin } from './fixtures/plugins/color';
+import { integerPlugin } from './fixtures/plugins/integer';
 import { pseudoPlugin } from './fixtures/plugins/pseudo';
 import { hoverTargetPlugin } from './fixtures/plugins/hoverTarget';
 import { breakpointPlugin } from './fixtures/plugins/breakpoint';
@@ -100,7 +102,7 @@ describe('generateCSS', () => {
       const classNames = ['mb2', 'mt10p', 'm3', 'mr1'];
       const config: BatteryConfig = {
         props: [margin],
-        plugins: [lengthUnitsPlugin],
+        plugins: [],
       };
       it('renders valid CSS', () => {
         testOutput(
@@ -119,7 +121,7 @@ describe('generateCSS', () => {
       const classNames = ['mx2', 'my50p'];
       const config: BatteryConfig = {
         props: [margin],
-        plugins: [lengthUnitsPlugin],
+        plugins: [],
       };
       it('renders valid CSS', () => {
         testOutput(
@@ -155,7 +157,7 @@ describe('generateCSS', () => {
             },
           },
         ],
-        plugins: [lengthUnitsPlugin],
+        plugins: [],
       };
       it('renders valid CSS', () => {
         testOutput(
@@ -177,17 +179,15 @@ describe('generateCSS', () => {
           {
             cssProperty: 'z-index',
             classNamespace: 'z',
-            valuePlugin: 'integer',
+            valuePlugin: integerPlugin(),
           },
           {
             cssProperty: 'flex',
             classNamespace: 'flex',
-            valuePlugin: 'integer',
+            valuePlugin: integerPlugin(),
           },
         ],
-        plugins: [
-          { type: 'pattern', name: 'integer', identifier: /-?\d{1,4}/ },
-        ],
+        plugins: [],
       };
 
       it('renders valid CSS', () => {
@@ -205,28 +205,15 @@ describe('generateCSS', () => {
           {
             cssProperty: 'width',
             classNamespace: 'w',
-            valuePlugin: 'lengthUnit',
+            valuePlugin: lengthUnitsPlugin(),
           },
           {
             cssProperty: 'height',
             classNamespace: 'h',
-            valuePlugin: 'lengthUnit',
+            valuePlugin: lengthUnitsPlugin(),
           },
         ],
-        plugins: [
-          {
-            type: 'pattern',
-            name: 'lengthUnit',
-            identifier: /-?\d{1,4}/,
-            modifiers: [
-              {
-                name: 'percent',
-                identifier: 'p',
-                modifierFn: value => `${value}%`,
-              },
-            ],
-          },
-        ],
+        plugins: [],
       };
 
       it('renders valid CSS', () => {
@@ -244,26 +231,10 @@ describe('generateCSS', () => {
           {
             cssProperty: 'margin',
             classNamespace: 'm',
-            valuePlugin: 'lengthUnit',
+            valuePlugin: lengthUnitsPlugin(),
           },
         ],
-        plugins: [
-          {
-            type: 'pattern',
-            name: 'lengthUnit',
-            identifier: /-?\d{1,4}/,
-            modifiers: [
-              {
-                name: 'baseline',
-                defaultModifier: true,
-                modifierFn: value => {
-                  const number = (parseInt(value) * 6) / 10;
-                  return `${number}rem`;
-                },
-              },
-            ],
-          },
-        ],
+        plugins: [],
       };
 
       it('renders valid CSS', () => {
@@ -280,22 +251,16 @@ describe('generateCSS', () => {
           {
             cssProperty: 'color',
             pluginDefault: true,
-            valuePlugin: 'color',
+            valuePlugin: colorPlugin(),
           },
           {
             cssProperty: 'background-color',
             classNamespace: 'bg',
             pluginSeparator: '-',
-            valuePlugin: 'color',
+            valuePlugin: colorPlugin(),
           },
         ],
-        plugins: [
-          {
-            type: 'lookup',
-            name: 'color',
-            values: { black: '#000000', white: '#FFFFFF' },
-          },
-        ],
+        plugins: [],
       };
 
       it('renders valid CSS', () => {
@@ -322,30 +287,16 @@ describe('generateCSS', () => {
           {
             cssProperty: 'color',
             pluginDefault: true,
-            valuePlugin: 'color',
+            valuePlugin: colorPlugin(),
           },
           {
             cssProperty: 'background-color',
             classNamespace: 'bg',
             pluginSeparator: '-',
-            valuePlugin: 'color',
+            valuePlugin: colorPlugin(),
           },
         ],
-        plugins: [
-          {
-            type: 'lookup',
-            name: 'color',
-            values: { black: '#000000', white: '#FFFFFF' },
-            modifiers: [
-              {
-                name: 'opacity',
-                modifierFn: hexToRgba,
-                separator: '_',
-                identifier: /\d+/,
-              },
-            ],
-          },
-        ],
+        plugins: [],
       };
 
       it('renders valid CSS', () => {
@@ -379,7 +330,7 @@ describe('generateCSS', () => {
           },
         },
       ],
-      plugins: [pseudoPlugin, hoverTargetPlugin],
+      plugins: [pseudoPlugin(), hoverTargetPlugin()],
     };
 
     describe('', () => {
@@ -414,7 +365,7 @@ describe('generateCSS', () => {
           },
         },
       ],
-      plugins: [breakpointPlugin],
+      plugins: [breakpointPlugin()],
     };
 
     describe('', () => {
@@ -468,7 +419,7 @@ describe('generateCSS', () => {
       ];
       const config: BatteryConfig = {
         props: [margin, backgroundSize, textAlign],
-        plugins: [lengthUnitsPlugin],
+        plugins: [],
       };
       it('renders valid CSS', () => {
         testOutput(
@@ -505,7 +456,7 @@ describe('generateCSS', () => {
       const classNames = ['m-auto', 'm-zzzz', 'm-inherit', 'm-base'];
       const config: BatteryConfig = {
         props: [margin],
-        plugins: [lengthUnitsPlugin],
+        plugins: [],
       };
       it('renders valid CSS', () => {
         testOutput(

--- a/src/generateCSS.test.ts
+++ b/src/generateCSS.test.ts
@@ -92,8 +92,7 @@ describe('generateCSS', () => {
           {
             cssProperty: 'background-color',
             classNamespace: 'bg',
-            pluginSeparator: '-',
-            valuePlugin: colorPlugin(),
+            valuePlugin: colorPlugin({ separator: '-' }),
           },
         ],
       };
@@ -287,8 +286,7 @@ describe('generateCSS', () => {
           {
             cssProperty: 'background-color',
             classNamespace: 'bg',
-            pluginSeparator: '-',
-            valuePlugin: colorPlugin(),
+            valuePlugin: colorPlugin({ separator: '-' }),
           },
         ],
         plugins: [],
@@ -323,8 +321,7 @@ describe('generateCSS', () => {
           {
             cssProperty: 'background-color',
             classNamespace: 'bg',
-            pluginSeparator: '-',
-            valuePlugin: colorPlugin(),
+            valuePlugin: colorPlugin({ separator: '-' }),
           },
         ],
         plugins: [],

--- a/src/matchers/generateKeywordMatcher.test.ts
+++ b/src/matchers/generateKeywordMatcher.test.ts
@@ -1,6 +1,7 @@
 import { generateKeywordMatcher } from '../matchers/generateKeywordMatcher';
 import { ClassMetaData } from '../types/classname';
-import { ModifierFn, PluginConfig } from '../types/plugin-config';
+import { pseudoPlugin } from '../fixtures/plugins/pseudo';
+import { PluginConfig } from '../types/plugin-config';
 
 describe('generateKeywordMatchers', () => {
   describe('Given a valid batteryConfig', () => {
@@ -50,28 +51,7 @@ describe('generateKeywordMatchers', () => {
 
   describe('Class plugins', () => {
     describe('Handle prefixes', () => {
-      const formatPseudo: ModifierFn = (cx, pseudo) => `${cx}:${pseudo}`;
-      const classPlugins: PluginConfig[] = [
-        {
-          name: 'pseudos',
-          type: 'selector',
-          affixType: 'prefix',
-          modifiers: [
-            {
-              name: 'hover',
-              separator: '-',
-              identifier: 'hover',
-              modifierFn: formatPseudo,
-            },
-            {
-              name: 'focus',
-              separator: '-',
-              identifier: 'focus',
-              modifierFn: formatPseudo,
-            },
-          ],
-        },
-      ];
+      const classPlugins: PluginConfig[] = [pseudoPlugin()];
 
       const classMetaData: ClassMetaData[] = [
         {

--- a/src/matchers/generateMatchers.test.ts
+++ b/src/matchers/generateMatchers.test.ts
@@ -36,7 +36,6 @@ describe('generateMatchers', () => {
       it('generates a regex to match classes associated with a specific plugin', () => {
         const colorPlugin: PluginConfig = {
           type: 'lookup',
-          name: 'color',
           values: {
             black: '#000000',
             white: '#ffffff',
@@ -50,22 +49,24 @@ describe('generateMatchers', () => {
               cssProperty: ['fill'],
               classNamespace: 'fill',
               pluginSeparator: '-',
-              valuePlugin: 'color',
+              valuePlugin: colorPlugin,
             },
             {
               cssProperty: ['background-color'],
               classNamespace: 'bg',
               pluginSeparator: '-',
-              valuePlugin: 'color',
+              valuePlugin: colorPlugin,
             },
             {
               cssProperty: ['color'],
               classNamespace: 'text',
               pluginDefault: true,
-              valuePlugin: 'color',
+              valuePlugin: colorPlugin,
             },
           ],
-          plugins: [colorPlugin],
+          plugins: {
+            colorPlugin,
+          },
         };
         expect(generateMatchers(config, []).color).toEqual(
           /(^)(fill-|bg-|)(black|white|pink)($)/,

--- a/src/matchers/generateMatchers.test.ts
+++ b/src/matchers/generateMatchers.test.ts
@@ -64,9 +64,7 @@ describe('generateMatchers', () => {
               valuePlugin: colorPlugin,
             },
           ],
-          plugins: {
-            colorPlugin,
-          },
+          plugins: [],
         };
         expect(generateMatchers(config, []).color).toEqual(
           /(^)(fill-|bg-|)(black|white|pink)($)/,

--- a/src/matchers/generateMatchers.test.ts
+++ b/src/matchers/generateMatchers.test.ts
@@ -66,9 +66,14 @@ describe('generateMatchers', () => {
           ],
           plugins: [],
         };
-        expect(generateMatchers(config, []).color).toEqual(
-          /(^)(fill-|bg-|)(black|white|pink)($)/,
-        );
+
+        const matchers = generateMatchers(config, []);
+
+        expect(matchers).toEqual({
+          color: /(^)()(black|white|pink)($)/,
+          fill: /(^)(fill-)(black|white|pink)($)/,
+          'background-color': /(^)(bg-)(black|white|pink)($)/,
+        });
       });
     });
   });

--- a/src/matchers/generateMatchers.test.ts
+++ b/src/matchers/generateMatchers.test.ts
@@ -36,6 +36,7 @@ describe('generateMatchers', () => {
       it('generates a regex to match classes associated with a specific plugin', () => {
         const colorPlugin: PluginConfig = {
           type: 'lookup',
+          separator: '-',
           values: {
             black: '#000000',
             white: '#ffffff',
@@ -48,13 +49,11 @@ describe('generateMatchers', () => {
             {
               cssProperty: ['fill'],
               classNamespace: 'fill',
-              pluginSeparator: '-',
               valuePlugin: colorPlugin,
             },
             {
               cssProperty: ['background-color'],
               classNamespace: 'bg',
-              pluginSeparator: '-',
               valuePlugin: colorPlugin,
             },
             {

--- a/src/matchers/generatePrefixSuffixMatchers.ts
+++ b/src/matchers/generatePrefixSuffixMatchers.ts
@@ -5,6 +5,7 @@ export const generatePrefixSuffixdMatchers = (plugins: PluginConfig[]) => {
     prefixes: '^',
     suffixes: '$',
   };
+
   if (!plugins || plugins.length < 1) {
     return baseObject;
   }

--- a/src/matchers/generateValuePluginMatcher.test.ts
+++ b/src/matchers/generateValuePluginMatcher.test.ts
@@ -1,33 +1,33 @@
+import { BatteryPlugin } from './../battery-plugin';
 import { generateValuePluginMatcher } from '../matchers/generateValuePluginMatcher';
 import { PluginConfig, ModifierFn } from '../types/plugin-config';
 import { DeveloperPropertyConfig } from '../types/property-config';
 
 describe('generateValuePluginMatcher', () => {
-  const colorPlugin: PluginConfig = {
+  const colorPlugin = BatteryPlugin({
     type: 'lookup',
     values: {
       black: '#000000',
       white: '#ffffff',
       pink: '#ff9dd8',
     },
-  };
+  });
+
   describe('Value plugins', () => {
     describe('Handle no multiple props', () => {
       it('Then it generates a regex to match classes using the plugin', () => {
-        const plugins: PluginConfig[] = [colorPlugin];
+        const plugins: PluginConfig[] = [];
 
         const props: DeveloperPropertyConfig[] = [
           {
             cssProperty: ['background-color'],
             classNamespace: 'bg',
-            pluginSeparator: '-',
-            valuePlugin: colorPlugin,
+            valuePlugin: colorPlugin({ separator: '-' }),
           },
           {
             cssProperty: ['fill'],
             classNamespace: 'fill',
-            pluginSeparator: '-',
-            valuePlugin: colorPlugin,
+            valuePlugin: colorPlugin({ separator: '-' }),
           },
         ];
 
@@ -39,13 +39,14 @@ describe('generateValuePluginMatcher', () => {
     });
 
     describe('Handle single prop set as plugin default', () => {
-      const plugins: PluginConfig[] = [colorPlugin];
+      const plugins: PluginConfig[] = [];
+
       const props: DeveloperPropertyConfig[] = [
         {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: colorPlugin,
+          valuePlugin: colorPlugin(),
         },
       ];
       it('generates a matcher', () => {
@@ -56,19 +57,18 @@ describe('generateValuePluginMatcher', () => {
     });
 
     describe('Handle multiple props with one set as plugin default', () => {
-      const plugins: PluginConfig[] = [colorPlugin];
+      const plugins: PluginConfig[] = [];
       const props: DeveloperPropertyConfig[] = [
         {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: colorPlugin,
+          valuePlugin: colorPlugin(),
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
-          pluginSeparator: '-',
-          valuePlugin: colorPlugin,
+          valuePlugin: colorPlugin({ separator: '-' }),
         },
       ];
 
@@ -81,7 +81,7 @@ describe('generateValuePluginMatcher', () => {
     });
 
     describe('Handle no props using the plugin', () => {
-      const plugins: PluginConfig[] = [colorPlugin];
+      const plugins: PluginConfig[] = [];
       const props: DeveloperPropertyConfig[] = [];
 
       it('does NOT generate a matcher', () => {
@@ -90,22 +90,21 @@ describe('generateValuePluginMatcher', () => {
     });
 
     describe('"Lookup" type plugin', () => {
-      const lookupPlugin: PluginConfig = {
+      const lookupPlugin = BatteryPlugin({
         type: 'lookup',
         values: {
           black: '#000000',
           white: '#ffffff',
           pink: '#ff9dd8',
         },
-      };
+      });
 
-      const plugins: PluginConfig[] = [lookupPlugin];
+      const plugins: PluginConfig[] = [];
       const props: DeveloperPropertyConfig[] = [
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
-          pluginSeparator: '-',
-          valuePlugin: lookupPlugin,
+          valuePlugin: lookupPlugin({ separator: '-' }),
         },
       ];
 
@@ -171,13 +170,12 @@ describe('generateValuePluginMatcher', () => {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: colorPlugin,
+          valuePlugin: colorPlugin(),
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
-          pluginSeparator: '-',
-          valuePlugin: colorPlugin,
+          valuePlugin: colorPlugin({ separator: '-' }),
         },
       ];
 
@@ -223,13 +221,12 @@ describe('generateValuePluginMatcher', () => {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: colorPlugin,
+          valuePlugin: colorPlugin(),
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
-          pluginSeparator: '-',
-          valuePlugin: colorPlugin,
+          valuePlugin: colorPlugin({ separator: '-' }),
         },
       ];
 

--- a/src/matchers/generateValuePluginMatcher.test.ts
+++ b/src/matchers/generateValuePluginMatcher.test.ts
@@ -32,8 +32,8 @@ describe('generateValuePluginMatcher', () => {
         ];
 
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
-          'background-color': /(^)(fill-|bg-)(black|white|pink)($)/,
-          fill: /(^)(fill-|bg-)(black|white|pink)($)/,
+          'background-color': /(^)(bg-)(black|white|pink)($)/,
+          fill: /(^)(fill-)(black|white|pink)($)/,
         });
       });
     });
@@ -50,7 +50,7 @@ describe('generateValuePluginMatcher', () => {
       ];
       it('generates a matcher', () => {
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
-          color: /(^)(black|white|pink)($)/,
+          color: /(^)()(black|white|pink)($)/,
         });
       });
     });
@@ -74,8 +74,8 @@ describe('generateValuePluginMatcher', () => {
 
       it('generates a matcher', () => {
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
-          color: /(^)(bg-|)(black|white|pink)($)/,
-          'background-color': /(^)(bg-|)(black|white|pink)($)/,
+          'background-color': /(^)(bg-)(black|white|pink)($)/,
+          color: /(^)()(black|white|pink)($)/,
         });
       });
     });
@@ -183,8 +183,8 @@ describe('generateValuePluginMatcher', () => {
 
       it('generates a matcher', () => {
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
-          color: /(hover-|focus-|^)(bg-|)(black|white|pink)($)/,
-          'background-color': /(hover-|focus-|^)(bg-|)(black|white|pink)($)/,
+          'background-color': /(hover-|focus-|^)(bg-)(black|white|pink)($)/,
+          color: /(hover-|focus-|^)()(black|white|pink)($)/,
         });
       });
     });
@@ -235,8 +235,8 @@ describe('generateValuePluginMatcher', () => {
 
       it('generates a matcher', () => {
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
-          color: /(^)(bg-|)(black|white|pink)(-sm|-md|-lg|$)/,
-          'background-color': /(^)(bg-|)(black|white|pink)(-sm|-md|-lg|$)/,
+          'background-color': /(^)(bg-)(black|white|pink)(-sm|-md|-lg|$)/,
+          color: /(^)()(black|white|pink)(-sm|-md|-lg|$)/,
         });
       });
     });

--- a/src/matchers/generateValuePluginMatcher.test.ts
+++ b/src/matchers/generateValuePluginMatcher.test.ts
@@ -5,7 +5,6 @@ import { DeveloperPropertyConfig } from '../types/property-config';
 describe('generateValuePluginMatcher', () => {
   const colorPlugin: PluginConfig = {
     type: 'lookup',
-    name: 'color',
     values: {
       black: '#000000',
       white: '#ffffff',
@@ -16,18 +15,19 @@ describe('generateValuePluginMatcher', () => {
     describe('Handle no multiple props', () => {
       it('Then it generates a regex to match classes using the plugin', () => {
         const plugins: PluginConfig[] = [colorPlugin];
+
         const props: DeveloperPropertyConfig[] = [
           {
             cssProperty: ['background-color'],
             classNamespace: 'bg',
             pluginSeparator: '-',
-            valuePlugin: 'color',
+            valuePlugin: colorPlugin,
           },
           {
             cssProperty: ['fill'],
             classNamespace: 'fill',
             pluginSeparator: '-',
-            valuePlugin: 'color',
+            valuePlugin: colorPlugin,
           },
         ];
 
@@ -44,7 +44,7 @@ describe('generateValuePluginMatcher', () => {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin,
         },
       ];
       it('generates a matcher', () => {
@@ -61,13 +61,13 @@ describe('generateValuePluginMatcher', () => {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin,
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: 'color',
+          valuePlugin: colorPlugin,
         },
       ];
 
@@ -90,7 +90,6 @@ describe('generateValuePluginMatcher', () => {
     describe('"Lookup" type plugin', () => {
       const lookupPlugin: PluginConfig = {
         type: 'lookup',
-        name: 'color',
         values: {
           black: '#000000',
           white: '#ffffff',
@@ -104,7 +103,7 @@ describe('generateValuePluginMatcher', () => {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: 'color',
+          valuePlugin: lookupPlugin,
         },
       ];
 
@@ -119,7 +118,6 @@ describe('generateValuePluginMatcher', () => {
     describe('"Pattern" type plugin', () => {
       const integerPlugin: PluginConfig = {
         type: 'pattern',
-        name: 'integer',
         identifier: /-?\d{1,4}/,
       };
 
@@ -130,7 +128,7 @@ describe('generateValuePluginMatcher', () => {
             {
               cssProperty: ['z-index'],
               classNamespace: 'z',
-              valuePlugin: 'integer',
+              valuePlugin: integerPlugin,
             },
           ];
 
@@ -146,7 +144,6 @@ describe('generateValuePluginMatcher', () => {
     describe('Handle prefixes', () => {
       const formatPseudo: ModifierFn = (cx, pseudo) => `${cx}:${pseudo}`;
       const pseudoPlugin: PluginConfig = {
-        name: 'pseudos',
         type: 'selector',
         affixType: 'prefix',
         modifiers: [
@@ -171,13 +168,13 @@ describe('generateValuePluginMatcher', () => {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: 'color',
+          valuePlugin: pseudoPlugin,
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: 'color',
+          valuePlugin: pseudoPlugin,
         },
       ];
 
@@ -190,7 +187,6 @@ describe('generateValuePluginMatcher', () => {
 
     describe('Handle suffixes', () => {
       const breakpointsPlugin: PluginConfig = {
-        name: 'breakpoints',
         type: 'at-rule',
         atrule: 'media',
         affixType: 'suffix',
@@ -223,13 +219,13 @@ describe('generateValuePluginMatcher', () => {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: 'color',
+          valuePlugin: breakpointsPlugin,
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: 'color',
+          valuePlugin: breakpointsPlugin,
         },
       ];
 

--- a/src/matchers/generateValuePluginMatcher.test.ts
+++ b/src/matchers/generateValuePluginMatcher.test.ts
@@ -32,7 +32,8 @@ describe('generateValuePluginMatcher', () => {
         ];
 
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
-          color: /(^)(fill-|bg-)(black|white|pink)($)/,
+          'background-color': /(^)(fill-|bg-)(black|white|pink)($)/,
+          fill: /(^)(fill-|bg-)(black|white|pink)($)/,
         });
       });
     });
@@ -74,6 +75,7 @@ describe('generateValuePluginMatcher', () => {
       it('generates a matcher', () => {
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
           color: /(^)(bg-|)(black|white|pink)($)/,
+          'background-color': /(^)(bg-|)(black|white|pink)($)/,
         });
       });
     });
@@ -133,7 +135,7 @@ describe('generateValuePluginMatcher', () => {
           ];
 
           expect(generateValuePluginMatcher(plugins, props)).toEqual({
-            integer: /(^)(z)(-?\d{1,4})($)/,
+            'z-index': /(^)(z)(-?\d{1,4})($)/,
           });
         });
       });
@@ -161,26 +163,28 @@ describe('generateValuePluginMatcher', () => {
           },
         ],
       };
-      const plugins: PluginConfig[] = [colorPlugin, pseudoPlugin];
+
+      const plugins: PluginConfig[] = [pseudoPlugin];
 
       const props: DeveloperPropertyConfig[] = [
         {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: pseudoPlugin,
+          valuePlugin: colorPlugin,
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: pseudoPlugin,
+          valuePlugin: colorPlugin,
         },
       ];
 
       it('generates a matcher', () => {
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
           color: /(hover-|focus-|^)(bg-|)(black|white|pink)($)/,
+          'background-color': /(hover-|focus-|^)(bg-|)(black|white|pink)($)/,
         });
       });
     });
@@ -212,26 +216,27 @@ describe('generateValuePluginMatcher', () => {
         ],
       };
 
-      const plugins: PluginConfig[] = [colorPlugin, breakpointsPlugin];
+      const plugins: PluginConfig[] = [breakpointsPlugin];
 
       const props: DeveloperPropertyConfig[] = [
         {
           cssProperty: ['color'],
           classNamespace: 'text',
           pluginDefault: true,
-          valuePlugin: breakpointsPlugin,
+          valuePlugin: colorPlugin,
         },
         {
           cssProperty: ['background-color'],
           classNamespace: 'bg',
           pluginSeparator: '-',
-          valuePlugin: breakpointsPlugin,
+          valuePlugin: colorPlugin,
         },
       ];
 
       it('generates a matcher', () => {
         expect(generateValuePluginMatcher(plugins, props)).toEqual({
           color: /(^)(bg-|)(black|white|pink)(-sm|-md|-lg|$)/,
+          'background-color': /(^)(bg-|)(black|white|pink)(-sm|-md|-lg|$)/,
         });
       });
     });

--- a/src/matchers/generateValuePluginMatcher.ts
+++ b/src/matchers/generateValuePluginMatcher.ts
@@ -60,7 +60,9 @@ const generatePropMatcher = (pluginPropConfigs: DeveloperPropertyConfig[]) => {
   const classNamespaces = pluginPropConfigs
     .filter(c => !c.pluginDefault)
     .map(propConfig => {
-      const { classNamespace, pluginSeparator = '' } = propConfig;
+      const { classNamespace, valuePlugin } = propConfig;
+      const pluginSeparator = (valuePlugin && valuePlugin.separator) || '';
+
       return `${classNamespace}${pluginSeparator}`;
     });
 

--- a/src/matchers/generateValuePluginMatcher.ts
+++ b/src/matchers/generateValuePluginMatcher.ts
@@ -30,7 +30,6 @@ const generateValueRegex = (
     : toCapture(valueArr);
 };
 
-//todo:fix types
 export const generateValueMatcher = (
   plugin: PluginConfig,
   captureSubGroups = false,
@@ -50,7 +49,7 @@ export const generateValueMatcher = (
 
       return generateValueRegex([identifier], plugin, captureSubGroups);
     default:
-      console.log(`The plugin "${plugin.name}" must have a type.`);
+      console.log(`The plugin must have a type.`);
   }
 };
 
@@ -88,10 +87,10 @@ export const generateValuePluginMatcher = (
   }
 
   const { prefixes, suffixes } = generatePrefixSuffixdMatchers(globalPlugins);
-  const propMatcher = generatePropMatcher(configsWithValuePlugins);
 
   const matchers: Matchers = configsWithValuePlugins.reduce(
     (accum: Matchers, config) => {
+      const propMatcher = generatePropMatcher([config]);
       const valueMatcher = generateValueMatcher(config.valuePlugin);
 
       const regex = new RegExp(

--- a/src/types/battery-config.ts
+++ b/src/types/battery-config.ts
@@ -3,10 +3,10 @@ import { PluginConfig } from './plugin-config';
 
 export interface BatteryConfig {
   props: PropertyConfig[];
-  plugins?: PluginConfig[];
+  plugins?: { [k: string]: PluginConfig };
 }
 
 export interface DeveloperBatteryConfig {
   props: DeveloperPropertyConfig[];
-  plugins?: PluginConfig[];
+  plugins?: { [k: string]: PluginConfig };
 }

--- a/src/types/battery-config.ts
+++ b/src/types/battery-config.ts
@@ -3,10 +3,10 @@ import { PluginConfig } from './plugin-config';
 
 export interface BatteryConfig {
   props: PropertyConfig[];
-  plugins?: { [k: string]: PluginConfig };
+  plugins?: PluginConfig[];
 }
 
 export interface DeveloperBatteryConfig {
   props: DeveloperPropertyConfig[];
-  plugins?: { [k: string]: PluginConfig };
+  plugins?: PluginConfig[];
 }

--- a/src/types/classname.ts
+++ b/src/types/classname.ts
@@ -25,7 +25,6 @@ export interface ClassMetaData {
   explodedSource?: ExplodedClassSource;
   keyword?: boolean;
   valuePlugin?: PluginConfig;
-  valuePluginType?: 'pattern' | 'lookup';
   atrulePlugin?: PluginConfig;
   atruleModifier?: string;
   selectorPlugin?: PluginConfig;

--- a/src/types/classname.ts
+++ b/src/types/classname.ts
@@ -1,4 +1,5 @@
 import { CSSProperties } from '../types/css';
+import { PluginConfig } from './plugin-config';
 
 export type ClassObject = { [key in CSSProperties]?: string };
 export interface ClassObjectGroup {
@@ -23,11 +24,11 @@ export interface ClassMetaData {
   selector?: string;
   explodedSource?: ExplodedClassSource;
   keyword?: boolean;
-  valuePlugin?: string;
+  valuePlugin?: PluginConfig;
   valuePluginType?: 'pattern' | 'lookup';
-  atrulePlugin?: string;
+  atrulePlugin?: PluginConfig;
   atruleModifier?: string;
-  selectorPlugin?: string;
+  selectorPlugin?: PluginConfig;
   selectorModifier?: string;
   valueModifier?: string;
   classObject?: ClassObject;

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -11,11 +11,13 @@ interface Modifier {
 
 export interface PluginConfig {
   type: 'pattern' | 'lookup' | 'selector' | 'at-rule';
-  name: string;
   atrule?: 'media' | 'font-face';
   affixType?: 'prefix' | 'suffix';
   identifier?: RegExp | string;
   modifiers?: Modifier[];
   sampleValues?: string[];
   values?: { [k: string]: string };
+
+  // todo: can this be more strictly typed?
+  static?: { [k: string]: string[] };
 }

--- a/src/types/plugin-config.ts
+++ b/src/types/plugin-config.ts
@@ -17,6 +17,7 @@ export interface PluginConfig {
   modifiers?: Modifier[];
   sampleValues?: string[];
   values?: { [k: string]: string };
+  separator?: string;
 
   // todo: can this be more strictly typed?
   static?: { [k: string]: string[] };

--- a/src/types/property-config.ts
+++ b/src/types/property-config.ts
@@ -21,7 +21,6 @@ interface CorePropertyConfig {
   pluginDefault?: boolean;
   subProps?: SubProp;
   subPropSeparator?: string;
-  pluginSeparator?: string;
   valueSeparator?: string;
   values?: { [k: string]: string };
   valuePlugin?: PluginConfig;

--- a/src/types/property-config.ts
+++ b/src/types/property-config.ts
@@ -1,4 +1,5 @@
 import { CSSProperties } from '../types/css';
+import { PluginConfig } from './plugin-config';
 
 export type SubPropKeys =
   | 'top'
@@ -23,7 +24,7 @@ interface CorePropertyConfig {
   pluginSeparator?: string;
   valueSeparator?: string;
   values?: { [k: string]: string };
-  valuePlugin?: string | ModifierSubset[];
+  valuePlugin?: PluginConfig;
 }
 
 export interface PropertyConfig extends CorePropertyConfig {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -3,7 +3,7 @@ export const baseToCapture = (nonCapture: boolean) => (
   optional = false,
 ) => {
   if (arr.length < 1) {
-    return '';
+    return '()';
   }
   const optionalRegex = optional ? '|' : '';
   const nonCaptureRegex = nonCapture ? '?:' : '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1031,6 +1031,18 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -2912,6 +2924,11 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
This PR reworks how Plugins are assigned to a `PropertyConfig`. Where previously plugins had a name and that name was referenced in the `valuePlugin` field on a `PropertyConfig`, we now include the entire PluginConfig. This also brings in the concept of the `BatteryPlugin` function which gives a user type-safety as well as allowing local overrides of `static` and `separator` at the `PropertyConfig` level.

This is foreshadowing for the new design of how Battery will be configured. Next we will tackle the `PropertyConfig` and introduce a `BatteryProperty` similar to the `BatteryPlugin`.